### PR TITLE
Open source license is missing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Lincoln Colling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Fischer 2003 Replication
+
+PsychToolBox code for the registered replication report of 
+the study Fischer, Castel, Dodd, & Pratt (2003). [doi:10.1038/nn1066](http://dx.doi.org/10.1038/nn1066)
+
+Copyright (c) 2016-2017 Lincoln Colling. Released under the [MIT license](http://opensource.org/licenses/MIT).
+
+For further information please see the [OSF project page](https://osf.io/he5za/).


### PR DESCRIPTION
Dear Lincoln,

I strongly recommend to specify explicitly the copyright and software licence when publishing code online. I typically use the MIT licence, which puts almost no restrictions on the re-use of the code. see e.g. https://choosealicense.com/  

You might want to be more restrictive. If so, fell free to reject this pull request.

Oliver (U Rotterdam)